### PR TITLE
Fix error in trajpoincare plot when c=0. 

### DIFF
--- a/Midterm 2 Files/Ex 1.ipynb
+++ b/Midterm 2 Files/Ex 1.ipynb
@@ -971,11 +971,13 @@
     "    if transpose == False:\n",
     "        ax[1].set_xlabel(r'Position, $x$')\n",
     "        ax[1].set_ylabel(r'Velocity, $v$')\n",
-    "        ax[1].set_xlim((c-abs(c/20),c+abs(c/20)))\n",
+    "        if c!=0:\n",
+    "            ax[1].set_xlim((c-abs(c/20),c+abs(c/20)))\n",
     "    else: #pay attention to the actual labels being set here.\n",
     "        ax[1].set_ylabel(r'Position, $x$')\n",
     "        ax[1].set_xlabel(r'Velocity, $v$')\n",
-    "        ax[1].set_ylim((c-abs(c/20),c+abs(c/20)))\n",
+    "        if c!=0:\n",
+    "            ax[1].set_ylim((c-abs(c/20),c+abs(c/20)))\n",
     "    ax[1].set_title(f'Poincaré section at x = {c} (crossings)')\n",
     "    ax[1].grid()\n",
     "    #plot of poincare section.\n",
@@ -996,9 +998,11 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "56",
    "metadata": {},
+   "outputs": [],
    "source": []
   }
  ],


### PR DESCRIPTION
the fix is just an error that matplotlib gives when c=0, which sets the limits of the sliced axis to (0,0).
opportunity to improve limit scaling on the graph; maybe a constant scaling is better, like (c-0.1,c+0.1) instead.